### PR TITLE
Update gradle teamcity plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.github.rodm:gradle-teamcity-plugin:0.8.4"
+        classpath "com.github.rodm:gradle-teamcity-plugin:0.9.1"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,4 @@ configure(subprojects - project(':build')) {
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
     }
-
-    repositories {
-        mavenCentral()
-    }
 }

--- a/build/build.gradle
+++ b/build/build.gradle
@@ -45,11 +45,15 @@ teamcity {
                 from awsSDKFiles()
             }
         }
-    }
 
-    homeDir = file(teamcityDir)
-    dataDir = file(teamcityDataDir)
-    javaHome = file(teamcityJavaHome)
+        environments {
+            teamcity10 {
+                homeDir = file(teamcityDir)
+                dataDir = file(teamcityDataDir)
+                javaHome = file(teamcityJavaHome)
+            }
+        }
+    }
 
     version = teamcityVersion
 }


### PR DESCRIPTION
Updates the build to use the latest version of the gradle-teamcity-plugin and to use the new environment configuration block. Also removes repository configuration that is provided by the plugin.

I see there is a 9.1.x branch, the changes could be applied to that branch with one change, the environment name, 'teamcity10', would need something more suitable.
