### PR TITLE
Ensure success published when 0 output aritfacts defined

### DIFF
--- a/aws-codepipeline-agent/src/main/java/jetbrains/buildServer/codepipeline/CodePipelineBuildListener.java
+++ b/aws-codepipeline-agent/src/main/java/jetbrains/buildServer/codepipeline/CodePipelineBuildListener.java
@@ -204,9 +204,8 @@ public class CodePipelineBuildListener extends AgentLifeCycleAdapter {
                   });
                 }
               });
-
-              publishJobSuccess(codePipelineClient, build);
             }
+            publishJobSuccess(codePipelineClient, build);
           }
         } catch (Throwable e) {
           failOnException(codePipelineClient, build, e);


### PR DESCRIPTION
#9 Position of publishJobSuccess call restricted success being reported  to only scenarios where at least one artifact was defined.